### PR TITLE
Support any attachment type

### DIFF
--- a/magic-paperlcip.gemspec
+++ b/magic-paperlcip.gemspec
@@ -25,4 +25,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'mocha'
   s.add_development_dependency 'shoulda'
   s.add_development_dependency 'sqlite3-ruby'
+  s.add_development_dependency 'fakeweb'
 end

--- a/test/content_type_test.rb
+++ b/test/content_type_test.rb
@@ -22,10 +22,6 @@ class ContentTypeTest < Test::Unit::TestCase
     setup do
       rebuild_model
       @file = File.new File.join( FIXTURES_DIR, 'zip_file_called.txt' )
-      class << @file
-        include Paperclip::Upfile
-      end
-
       @file.stubs(:content_type).returns("") # Some versions of chrome do this
       @dummy = Dummy.new
       @dummy.avatar = @file
@@ -34,6 +30,20 @@ class ContentTypeTest < Test::Unit::TestCase
     should "set content_type based on file magic" do
       assert_equal "application/zip", @dummy.avatar.content_type
       assert_equal "application/zip", @dummy.avatar_content_type
+    end
+  end
+
+  context "Assigning a URI" do
+    setup do
+      rebuild_model
+      FakeWeb.register_uri(:get, "http://foo.bar/avatar", :body => "o(^_^)o", :content_type => "image/png")
+      @dummy = Dummy.new
+      @dummy.avatar = URI.parse("http://foo.bar/avatar")
+    end
+
+    should "not invoke file magic, maintaining the content_type from the response" do
+      assert_equal "text/plain", @dummy.avatar.content_type
+      assert_equal "text/plain", @dummy.avatar_content_type
     end
   end
 end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -1,9 +1,10 @@
 # Copied from Paperclip's own test suite
 
+require 'test/unit'
 require 'active_record'
+require 'fakeweb'
 require 'mocha'
 require 'shoulda'
-require 'test/unit'
 
 require 'magic-paperclip'
 


### PR DESCRIPTION
Thanks for developing this gem!

This patch fixes errors when URIs are assigned to paperclip attachments. It takes advantage of the fact that paperclip's IO adapters always provide a path to a tempfile, at least in recent versions of paperclip (v3.1+).

Other tweaks:
- Require test/unit before mocha to eliminate warnings.
- Use tap so I don't have to remember to explicitly return the value from assign_without_filemagic.
